### PR TITLE
Added newline char to merge script

### DIFF
--- a/assignments/week-01/day-04/README.md
+++ b/assignments/week-01/day-04/README.md
@@ -234,7 +234,7 @@ yamls="$(ls -1 "${DIRECTORY}")"
 
 for yaml in ${yamls}; do
     cat "${DIRECTORY}/${yaml}"
-    echo "---"
+    echo $'\n---'
 done
 
 exit 0


### PR DESCRIPTION
The merge script was not adding a newline before the `---` separator when it was merging the `.yaml` documents. e.g. instead of:

```yaml
  selector:
    app: httpbin
---
```

I was getting:

```yaml
  selector:
    app: httpbin---
```
which caused problems in the deployment job in the CircleCI pipeline. 

Adding a `\n` char before `---` in the merge script fixed this problem, at least in my case.

Note: I had to enclose the characters with a single quote ( ' ) instead of double quotes ( " ) for this to work.